### PR TITLE
Fixed #2 -- inline checkbox & radio errors

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/checkboxselectmultiple.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/checkboxselectmultiple.html
@@ -15,11 +15,9 @@
     </div>
    {% endfor %}
     {% if field.errors and inline_class %}
-    <div class="w-100 {%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
-        {# the following input is only meant to allow boostrap to render the error message as it has to be after an invalid input. As the input has no name, no data will be sent. #}
-        <input type="checkbox" class="custom-control-input {% if field.errors %}is-invalid{%endif%}">
-        {% include 'bootstrap5/layout/field_errors_block.html' %}
-
+        {% for error in field.errors %}
+            <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="text-danger mb-0"><small><strong>{{ error }}</strong></small></p>
+        {% endfor %}
     {% endif %}
 
     {% include 'bootstrap5/layout/help_text.html' %}

--- a/crispy_bootstrap5/templates/bootstrap5/layout/radioselect.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/radioselect.html
@@ -15,11 +15,9 @@
      </div>
     {% endfor %}
     {% if field.errors and inline_class %}
-    <div class="w-100 form-check{% if inline_class %} form-check-inline{% endif %}">
-        {# the following input is only meant to allow boostrap to render the error message as it has to be after an invalid input. As the input has no name, no data will be sent. #}
-        <input type="checkbox" class="custom-control-input {% if field.errors %}is-invalid{%endif%}">
-        {% include 'bootstrap5/layout/field_errors_block.html' %}
-
+        {% for error in field.errors %}
+            <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="text-danger mb-0"><small><strong>{{ error }}</strong></small></p>
+        {% endfor %}
     {% endif %}
 
     {% include 'bootstrap5/layout/help_text.html' %}


### PR DESCRIPTION
I don't particularly like this as it doesn't use the `invalid-feedback` class and it repeats logic in the templates for the errors. 

However, it does seem to look ok. :shrug: 

Before 
![image](https://user-images.githubusercontent.com/39445562/98597655-3ead8300-22d1-11eb-9512-b2bfbb7f4ef2.png)

After 
![image](https://user-images.githubusercontent.com/39445562/98597702-508f2600-22d1-11eb-836b-43a6724025bf.png)
