### PR TITLE
Fix package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include MANIFEST.in
+include README.md
+recursive-include crispy_bootstrap5/templates *

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,6 @@ setup(
     extras_require={"test": ["pytest", "pytest-django"]},
     tests_require=["crispy-bootstrap5[test]"],
     python_requires=">=3.6",
+    zip_safe=False,
+    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,5 @@ setup(
     extras_require={"test": ["pytest", "pytest-django"]},
     tests_require=["crispy-bootstrap5[test]"],
     python_requires=">=3.6",
-    zip_safe=False,
     include_package_data=True,
 )


### PR DESCRIPTION
@carltongibson

`crispy-forms` uses `zip_safe=False` in it's `setup.py` file. 

Testing locally this package seems to work 'just fine' without this setting. I think we can rely on auto-detection? Do you have a view on this?

https://setuptools.readthedocs.io/en/latest/userguide/miscellaneous.html?highlight=zip_safe#setting-the-zip-safe-flag
