### PR TITLE
Accordion

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/accordion-group.html
+++ b/crispy_bootstrap5/templates/bootstrap5/accordion-group.html
@@ -1,17 +1,15 @@
-<div class="card mb-2">
-    <div class="card-header" role="tab">
-        <h5 class="mb-0">
-            <a data-toggle="collapse" href="#{{ div.css_id }}" aria-expanded="true"
-               aria-controls="{{ div.css_id }}">
-                {{ div.name }}
-            </a>
-        </h5>
-    </div>
+<div class="accordion-item">
+    <h2 class="accordion-header">
+        <button class="accordion-button{% if not div.active %} collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#{{ div.css_id }}" aria-expanded="true"
+            aria-controls="{{ div.css_id }}">
+            {{ div.name }}
+        </button>
+    </h2>
 
-    <div id="{{ div.css_id }}" class="collapse{% if div.active %} show{% endif %}" role="tabpanel"
-         aria-labelledby="{{ div.css_id }}" data-parent="#accordion">
-        <div class="card-body">
+    <div id="{{ div.css_id }}" class="accordion-collapse collapse{% if div.active %} show{% endif %}"
+         aria-labelledby="{{ div.css_id }}" data-bs-parent="#accordion">
+        <div class="accordion-body">
             {{ fields|safe }}
         </div>
-    </div>
+    </div>  
 </div>

--- a/crispy_bootstrap5/templates/bootstrap5/accordion.html
+++ b/crispy_bootstrap5/templates/bootstrap5/accordion.html
@@ -1,3 +1,3 @@
-<div id="accordion" role="tablist">
+<div class="accordion" id="accordion">
     {{ content|safe }}
 </div>

--- a/tests/results/accordion.html
+++ b/tests/results/accordion.html
@@ -1,0 +1,53 @@
+<div class="accordion" id="accordion">
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#one"
+        aria-expanded="true" aria-controls="one">
+        one
+      </button>
+    </h2>
+    <div id="one" class="accordion-collapse collapse show" aria-labelledby="one" data-bs-parent="#accordion">
+      <div class="accordion-body">
+        <div id="div_id_first_name" class="mb-3">
+          <label for="id_first_name" class="form-label requiredField">
+            first name<span class="asteriskField">*</span>
+          </label>
+          <div>
+            <input type="text" name="first_name" maxlength="5" class="textinput textInput inputtext form-control"
+              required id="id_first_name" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#two"
+        aria-expanded="true" aria-controls="two">
+        two
+      </button>
+    </h2>
+    <div id="two" class="accordion-collapse collapse" aria-labelledby="two" data-bs-parent="#accordion">
+      <div class="accordion-body">
+        <div id="div_id_password1" class="mb-3">
+          <label for="id_password1" class="form-label requiredField">
+            password<span class="asteriskField">*</span>
+          </label>
+          <div>
+            <input type="password" name="password1" maxlength="30" class="textinput textInput form-control" required
+              id="id_password1" />
+          </div>
+        </div>
+        <div id="div_id_password2" class="mb-3">
+          <label for="id_password2" class="form-label requiredField">
+            re-enter password<span class="asteriskField">*</span>
+          </label>
+          <div>
+            <input type="password" name="password2" maxlength="30" class="textinput textInput form-control" required
+              id="id_password2" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -227,25 +227,16 @@ class TestBootstrapLayoutObjects:
         assert html.count('form-check-inline"') == 2
 
     def test_accordion_and_accordiongroup(self, settings):
-        test_form = SampleForm()
-        test_form.helper = FormHelper()
-        test_form.helper.layout = Layout(
+        form = SampleForm()
+        form.helper = FormHelper()
+        form.helper.form_tag = False
+        form.helper.layout = Layout(
             Accordion(
                 AccordionGroup("one", "first_name"),
                 AccordionGroup("two", "password1", "password2"),
             )
         )
-        html = render_crispy_form(test_form)
-
-        assert html.count('<div id="accordion"') == 1
-        assert html.count('<div class="card mb-2"') == 2
-        assert html.count('<div class="card-header"') == 2
-
-        assert html.count('<div id="one"') == 1
-        assert html.count('<div id="two"') == 1
-        assert html.count('name="first_name"') == 1
-        assert html.count('name="password1"') == 1
-        assert html.count('name="password2"') == 1
+        assert parse_form(form) == parse_expected("accordion.html")
 
     def test_accordion_active_false_not_rendered(self, settings):
         test_form = SampleForm()
@@ -262,7 +253,10 @@ class TestBootstrapLayoutObjects:
 
         accordion_class = "collapse show"
 
-        assert html.count('<div id="one" class="%s"' % accordion_class) == 1
+        assert (
+            html.count('<div id="one" class="accordion-collapse %s"' % accordion_class)
+            == 1
+        )
 
         test_form.helper.layout = Layout(
             Accordion(
@@ -272,7 +266,10 @@ class TestBootstrapLayoutObjects:
 
         # This time, it shouldn't be there at all.
         html = render_crispy_form(test_form)
-        assert html.count('<div id="one" class="%s collapse in"' % accordion_class) == 0
+        assert (
+            html.count('<div id="one" class="accordion-collapse %s"' % accordion_class)
+            == 0
+        )
 
     def test_alert(self):
         test_form = SampleForm()


### PR DESCRIPTION
Fixes #21 

As noted in the issue the release blog(2) announced the new accordion. It isn't; however, mentioned in the migration docs (3):shrug:. I've also linked to the relevant section in the docs(1)

There are a few changes here but nothing too major, mainly a few class name changes. You'll also see that bootstrap5 has started to use add `bs` to the data attributes. 

This is based upon #23 so we need to get that in first. 

1 - [Docs](https://getbootstrap.com/docs/5.0/components/accordion/)
2 - [Release Blog](https://blog.getbootstrap.com/2020/11/11/bootstrap-5-alpha-3/)
3 - [Migration](https://getbootstrap.com/docs/5.0/migration/)