### PR TITLE
Updated pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
-  -   repo: https://github.com/timothycrosley/isort
+  -   repo: https://github.com/pycqa/isort
       rev: 5.7.0
       hooks:
       - id: isort


### PR DESCRIPTION
isort now resides under the pycqa org