### PR TITLE
Moved field_class div within if statement

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/field.html
@@ -36,7 +36,7 @@
                 </label>
                 {% include 'bootstrap5/layout/help_text_and_errors.html' %}
             {% else %}
-                <div {% if field_class %}class="{{ field_class }}"{% endif %}>
+                {% if field_class %}<div class="{{ field_class }}">{% endif %}
                     {% if field|is_file and field|is_clearable_file %}
                     {# clearable files are more complex, potentially need a checkbox -- let Django render these for now #}
                         {% crispy_field field %}
@@ -52,7 +52,7 @@
                         {% crispy_field field 'class' 'form-control' %}
                     {% endif %}
                     {% include 'bootstrap5/layout/help_text_and_errors.html' %}
-                </div>
+                {% if field_class %}</div>{% endif %}
             {% endif %}
         {% endif %}
     </{% if tag %}{{ tag }}{% else %}div{% endif %}>

--- a/tests/results/accordion.html
+++ b/tests/results/accordion.html
@@ -12,10 +12,8 @@
           <label for="id_first_name" class="form-label requiredField">
             first name<span class="asteriskField">*</span>
           </label>
-          <div>
-            <input type="text" name="first_name" maxlength="5" class="textinput textInput inputtext form-control"
-              required id="id_first_name" />
-          </div>
+          <input type="text" name="first_name" maxlength="5" class="textinput textInput inputtext form-control" required
+            id="id_first_name" />
         </div>
       </div>
     </div>
@@ -33,19 +31,15 @@
           <label for="id_password1" class="form-label requiredField">
             password<span class="asteriskField">*</span>
           </label>
-          <div>
-            <input type="password" name="password1" maxlength="30" class="textinput textInput form-control" required
-              id="id_password1" />
-          </div>
+          <input type="password" name="password1" maxlength="30" class="textinput textInput form-control" required
+            id="id_password1" />
         </div>
         <div id="div_id_password2" class="mb-3">
           <label for="id_password2" class="form-label requiredField">
             re-enter password<span class="asteriskField">*</span>
           </label>
-          <div>
-            <input type="password" name="password2" maxlength="30" class="textinput textInput form-control" required
-              id="id_password2" />
-          </div>
+          <input type="password" name="password2" maxlength="30" class="textinput textInput form-control" required
+            id="id_password2" />
         </div>
       </div>
     </div>

--- a/tests/results/test_select.html
+++ b/tests/results/test_select.html
@@ -1,10 +1,10 @@
 <form method="post">
     <div id="div_id_select_input" class="mb-3"> <label for="id_select_input" class="form-label requiredField"> Select
             input<span class="asteriskField">*</span> </label>
-        <div> <select name="select_input" class="select form-select" id="id_select_input">
-                <option value="1">Option one</option>
-                <option value="2">Option two</option>
-                <option value="3">Option three</option>
-            </select> </div>
+        <select name="select_input" class="select form-select" id="id_select_input">
+            <option value="1">Option one</option>
+            <option value="2">Option two</option>
+            <option value="3">Option three</option>
+        </select>
     </div>
 </form>

--- a/tests/results/text_area.html
+++ b/tests/results/text_area.html
@@ -3,7 +3,6 @@
     <label for="id_text_area" class="form-label requiredField">
       Text area<span class="asteriskField">*</span>
     </label>
-    <div>
       <textarea
         name="text_area"
         cols="40"
@@ -12,6 +11,5 @@
         required
         id="id_text_area"
       ></textarea>
-    </div>
   </div>
 </form>

--- a/tests/results/text_input.html
+++ b/tests/results/text_input.html
@@ -5,9 +5,7 @@
                 *
             </span>
         </label>
-        <div>
-            <input class="form-control inputtext textInput textinput" id="id_text_input" name="text_input"
-                required type="text">
-        </div>
+        <input class="form-control inputtext textInput textinput" id="id_text_input" name="text_input" required
+            type="text">
     </div>
 </form>


### PR DESCRIPTION
It seems that bootstrap5 has limited use for field_class as the labels and divs are now siblings for each other. wrapping_class is on the div wrapping both the label and input is more likely to be used. This change is needed as the new bs5 floating labels need to be siblings.

The impact of this change is to remove many empty `div`s which wrap the inputs. 