### PR TITLE
Modify row template to class "row"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG FOR CRISPY-BOOTSTRAP5
 
+## 0.3.1(2021-03-03)
+* Fixed classes for `row` layout object (#36)
+
+See [Milestones](https://github.com/django-crispy-forms/crispy-bootstrap5/milestone/4?closed=1) for full changelog.
+
 ## 0.3 (2021-02-21)
 * Fixed rendering of select widgets (#31)
 

--- a/crispy_bootstrap5/templates/bootstrap5/layout/row.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/row.html
@@ -1,3 +1,3 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="form-row {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
-        {{ fields|safe }}
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="row {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+  {{ fields|safe }}
 </div>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup
 
-VERSION = "0.3"
+VERSION = "0.3.1"
 
 
 def get_long_description():

--- a/tests/results/row.html
+++ b/tests/results/row.html
@@ -1,0 +1,18 @@
+<form method="post">
+    <div class="row ">
+        <div class="col-md ">
+            <div id="div_id_first_name" class="mb-3"> <label for="id_first_name" class="form-label requiredField"> first
+                    name<span class="asteriskField">*</span> </label>
+                <div> <input type="text" name="first_name" maxlength="5"
+                        class="textinput textInput inputtext form-control" required id="id_first_name"> </div>
+            </div>
+        </div>
+        <div class="col-md ">
+            <div id="div_id_last_name" class="mb-3"> <label for="id_last_name" class="form-label requiredField"> last
+                    name<span class="asteriskField">*</span> </label>
+                <div> <input type="text" name="last_name" maxlength="5"
+                        class="textinput textInput inputtext form-control" required id="id_last_name"> </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -195,7 +195,7 @@ def test_layout_fieldset_row_html_with_unicode_fieldnames(settings):
     assert 'id="row_passwords"' in html
     assert html.count("<label") == 6
 
-    assert 'class="form-row rows"' in html
+    assert 'class="row rows"' in html
 
     assert "Hello!" in html
     assert "testLink" in html
@@ -550,3 +550,15 @@ def test_file_field():
         '<input type="file" name="file_field" class="fileinput fileUpload '
         'form-control" required id="id_file_field">' in html
     )
+
+
+def test_row():
+    form = SampleForm()
+    form.helper = FormHelper()
+    form.helper.layout = Layout(
+        Row(
+            Column("first_name"),
+            Column("last_name"),
+        )
+    )
+    assert parse_form(form) == parse_expected("row.html")


### PR DESCRIPTION
Class "form-row" doesn't seem to do anything in bootstrap5. Class "row" seems to apply the proposed style for Row in crispy-forms.