### PR TITLE
Bootstrap 5 uses data-bs-toggle instead of data-toggle

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/tab-link.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/tab-link.html
@@ -1,1 +1,1 @@
-<li class="nav-item"><a class="nav-link{% if 'active' in link.css_class %} active{% endif %}" href="#{{ link.css_id }}" data-toggle="tab">{{ link.name|capfirst }}{% if tab.errors %}!{% endif %}</a></li>
+<li class="nav-item"><a class="nav-link{% if 'active' in link.css_class %} active{% endif %}" href="#{{ link.css_id }}" data-bs-toggle="tab">{{ link.name|capfirst }}{% if tab.errors %}!{% endif %}</a></li>

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -310,7 +310,7 @@ class TestBootstrapLayoutObjects:
         assert (
             html.count(
                 '<ul class="nav nav-tabs"> <li class="nav-item">'
-                '<a class="nav-link active" href="#custom-name" data-toggle="tab">'
+                '<a class="nav-link active" href="#custom-name" data-bs-toggle="tab">'
                 "One</a></li>"
             )
             == 1


### PR DESCRIPTION
Fixes a Bootstrap 4 leftover in a template