### PR TITLE
set proper class on check box for inline display

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/field.html
@@ -46,6 +46,8 @@
                         {% else %}
                             {% crispy_field field 'class' 'form-select' %}
                         {% endif %}
+		    {% elif field|is_checkbox %}
+                        {% crispy_field field 'class' 'form-check_input' %}
                     {% elif field.errors %}
                         {% crispy_field field 'class' 'form-control is-invalid' %}
                     {% else %}


### PR DESCRIPTION
This fix the issue with checkbox in inline formset that would not render properly due to incorrect form-control class.

Nevertheless, there's still an issue, as the checkbox is rendered as "standard" checkbox, but not with boostrap5 style. 