### PR TITLE
Fix layout of checkbox by adding correct css classes

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/field.html
@@ -9,7 +9,7 @@
             <div class="{% for offset in bootstrap_checkbox_offsets %}{{ offset }} {% endfor %}{{ field_class }}">
         {% endif %}
     {% endif %}
-    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="{% if not field|is_checkbox %}mb-3{% if 'form-horizontal' in form_class %} row{% endif %}{% else %}form-check{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="mb-3{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
             <label {% if field.id_for_label %}for="{{ field.id_for_label }}"{% endif %} class="{% if 'form-horizontal' in form_class %}col-form-label{% else %}form-label{% endif %}{% if label_class %} {{ label_class }}{% endif %}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
@@ -46,6 +46,8 @@
                         {% else %}
                             {% crispy_field field 'class' 'form-select' %}
                         {% endif %}
+                    {% elif field|is_checkbox %}
+                        {% crispy_field field 'class' 'form-check-input' %}
                     {% elif field.errors %}
                         {% crispy_field field 'class' 'form-control is-invalid' %}
                     {% else %}


### PR DESCRIPTION
The css classes of checkboxes causes broken display. This patch fixes the classes.

Before (two columns):

![before](https://user-images.githubusercontent.com/476440/116973552-1347a600-ad00-11eb-9a2f-f07deb69fe54.png)

After (two columns):

![after](https://user-images.githubusercontent.com/476440/116973566-1773c380-ad00-11eb-9443-3fa01e85891e.png)
