### PR TITLE
Removed |safe from flat_attrs

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/baseinput.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/baseinput.html
@@ -5,5 +5,5 @@
         class="{{ input.field_classes }}"
         id="{% if input.id %}{{ input.id }}{% else %}{{ input.input_type }}-id-{{ input.name|slugify }}{% endif %}"
     {% endif %}
-    {{ input.flat_attrs|safe }}
+    {{ input.flat_attrs }}
     />

--- a/crispy_bootstrap5/templates/bootstrap5/layout/button.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/button.html
@@ -1,1 +1,1 @@
-<button {{ button.flat_attrs|safe }}>{{ button.content|safe }}</button>
+<button {{ button.flat_attrs }}>{{ button.content|safe }}</button>

--- a/crispy_bootstrap5/templates/bootstrap5/layout/checkboxselectmultiple.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/checkboxselectmultiple.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs }}{% endif %}>
 
     {% for choice in field.field.choices %}
     <div class="form-check{% if inline_class %} form-check-inline{% endif %}">

--- a/crispy_bootstrap5/templates/bootstrap5/layout/column.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/column.html
@@ -1,5 +1,5 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %}
-     class="{% if 'col' in div.css_class %}{{ div.css_class|default:'' }}{% else %}col-md {{ div.css_class|default:'' }}{% endif %}" {{ div.flat_attrs|safe }}>
+     class="{% if 'col' in div.css_class %}{{ div.css_class|default:'' }}{% else %}col-md {{ div.css_class|default:'' }}{% endif %}" {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>
 

--- a/crispy_bootstrap5/templates/bootstrap5/layout/div.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
-    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
+    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>

--- a/crispy_bootstrap5/templates/bootstrap5/layout/field_with_buttons.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/field_with_buttons.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="mb-3{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="mb-3{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="{% if 'form-horizontal' in form_class %}col-form-label {% else %}form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_bootstrap5/templates/bootstrap5/layout/fieldset.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/fieldset.html
@@ -1,6 +1,6 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
     {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
-    {{ fieldset.flat_attrs|safe }}>
+    {{ fieldset.flat_attrs }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
     {{ fields|safe }} 
 </fieldset>

--- a/crispy_bootstrap5/templates/bootstrap5/layout/formactions.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/formactions.html
@@ -1,4 +1,4 @@
-<div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="mb-3">
+<div{% if formactions.attrs %} {{ formactions.flat_attrs }}{% endif %} class="mb-3">
     {% if label_class %}
         <div class="aab {{ label_class }}"></div>
     {% endif %}

--- a/crispy_bootstrap5/templates/bootstrap5/layout/radioselect.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/radioselect.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs }}{% endif %}>
 
     {% for choice in field.field.choices %}
       <div class="form-check{% if inline_class %} form-check-inline{% endif %}">

--- a/crispy_bootstrap5/templates/bootstrap5/layout/row.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/row.html
@@ -1,3 +1,3 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="row {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="row {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
   {{ fields|safe }}
 </div>

--- a/crispy_bootstrap5/templates/bootstrap5/table_inline_formset.html
+++ b/crispy_bootstrap5/templates/bootstrap5/table_inline_formset.html
@@ -4,7 +4,7 @@
 
 {% specialspaceless %}
 {% if formset_tag %}
-<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+<form {{ flat_attrs }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
     {% if formset_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}

--- a/crispy_bootstrap5/templates/bootstrap5/whole_uni_form.html
+++ b/crispy_bootstrap5/templates/bootstrap5/whole_uni_form.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_utils %}
 
 {% specialspaceless %}
-{% if form_tag %}<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
+{% if form_tag %}<form {{ flat_attrs }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
     {% if form_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}
     {% endif %}

--- a/crispy_bootstrap5/templates/bootstrap5/whole_uni_formset.html
+++ b/crispy_bootstrap5/templates/bootstrap5/whole_uni_formset.html
@@ -3,7 +3,7 @@
 
 {% specialspaceless %}
 {% if formset_tag %}
-<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+<form {{ flat_attrs }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
     {% if formset_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}

--- a/tests/results/flat_attrs.html
+++ b/tests/results/flat_attrs.html
@@ -1,0 +1,1 @@
+<div aria-labelledby="test<>%" class=" row">

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -628,3 +628,15 @@ def test_tabular_formset_layout():
     assert parse_form(formset) == parse_expected(
         "test_tabular_formset_layout_failing.html"
     )
+
+
+def test_flat_attrs_safe():
+    form = SampleForm()
+    form.helper = FormHelper()
+    form.helper.layout = Layout(
+        Row(
+            aria_labelledby="test<>%",
+        )
+    )
+    form.helper.form_tag = False
+    assert parse_form(form) == parse_expected("flat_attrs.html")


### PR DESCRIPTION
There's no behaviour change here. I think it's due to `flat_attrs` already being `mark_safe`ed by the django function it wraps.

`The result is passed through 'mark_safe' (by way of 'format_html_join').`

https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/forms/utils.py#L27