### PR TITLE
Improved test_tab_and_tab_holder

### DIFF
--- a/tests/results/test_tab_and_tab_holder.html
+++ b/tests/results/test_tab_and_tab_holder.html
@@ -1,0 +1,22 @@
+<form method="post">
+    <ul class="nav nav-tabs">
+        <li class="nav-item"><a class="nav-link active" href="#custom-name" data-bs-toggle="tab">One</a></li>
+        <li class="nav-item"><a class="nav-link" href="#two" data-bs-toggle="tab">Two</a></li>
+    </ul>
+    <div class="tab-content card-body">
+        <div id="custom-name" class="tab-pane first-tab-class active">
+            <div id="div_id_first_name" class="mb-3"> <label for="id_first_name" class="form-label requiredField"> first
+                    name<span class="asteriskField">*</span> </label> <input type="text" name="first_name" maxlength="5"
+                    class="textinput textInput inputtext form-control" required id="id_first_name"> </div>
+        </div>
+        <div id="two" class="tab-pane">
+            <div id="div_id_password1" class="mb-3"> <label for="id_password1" class="form-label requiredField">
+                    password<span class="asteriskField">*</span> </label> <input type="password" name="password1"
+                    maxlength="30" class="textinput textInput form-control" required id="id_password1"> </div>
+            <div id="div_id_password2" class="mb-3"> <label for="id_password2" class="form-label requiredField">
+                    re-enter password<span class="asteriskField">*</span> </label> <input type="password"
+                    name="password2" maxlength="30" class="textinput textInput form-control" required id="id_password2">
+            </div>
+        </div>
+    </div>
+</form>

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -293,7 +293,7 @@ class TestBootstrapLayoutObjects:
         assert html.count('<div class="alert alert-block"') == 1
         assert html.count("Testing...") == 1
 
-    def test_tab_and_tab_holder(self, settings):
+    def test_tab_and_tab_holder(self):
         test_form = SampleForm()
         test_form.helper = FormHelper()
         test_form.helper.layout = Layout(
@@ -307,25 +307,7 @@ class TestBootstrapLayoutObjects:
                 Tab("two", "password1", "password2"),
             )
         )
-        html = render_crispy_form(test_form)
-
-        assert (
-            html.count(
-                '<ul class="nav nav-tabs"> <li class="nav-item">'
-                '<a class="nav-link active" href="#custom-name" data-bs-toggle="tab">'
-                "One</a></li>"
-            )
-            == 1
-        )
-        assert html.count("tab-pane") == 2
-
-        assert html.count('class="tab-pane first-tab-class active"') == 1
-
-        assert html.count('<div id="custom-name"') == 1
-        assert html.count('<div id="two"') == 1
-        assert html.count('name="first_name"') == 1
-        assert html.count('name="password1"') == 1
-        assert html.count('name="password2"') == 1
+        assert parse_form(test_form) == parse_expected("test_tab_and_tab_holder.html")
 
     def test_tab_helper_reuse(self):
         # this is a proper form, according to the docs.


### PR DESCRIPTION
I was going to use this to demonstrate the change in removing another `|safe` filter but this is actually a broken layout. 

I'll leave this here while I carry on with my current trail of thought. Contributions welcome for anyone following along at home 😄 

Docs Link: https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior

