### PR TITLE
Removal of |safe on fields

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/row.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/row.html
@@ -1,3 +1,3 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="row {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
-  {{ fields|safe }}
+  {{ fields }}
 </div>


### PR DESCRIPTION
This is just to discuss removal of more `|safe` filters. 

In this case fields is the output of the field's templates which is HTML. This will result in a nicely rendered form being escaped to something like this. See the expected test failures for the full diff. 

``` html
&lt;div class=&quot;col-md &quot; &gt; &lt;div id=&quot;div_id_first_name&quot; class=&quot;mb-3&quot;&gt; 
```

I guess the other way, would be to use more `mark_safe()` when calling `render()` and related methods 🤔 . For example [here](https://github.com/django-crispy-forms/django-crispy-forms/blob/0a7f429d69d9ced613f0e9bc2e2dbd2dccb0af09/crispy_forms/layout.py#L96) 

I think in practice these two options would be similar; however, folk seem to be a bit more nervous about `|safe`. Does this matter, is the change worth it?

Appreciate comments. 
