### PR TITLE
Fix data-bs-parent

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/accordion-group.html
+++ b/crispy_bootstrap5/templates/bootstrap5/accordion-group.html
@@ -7,7 +7,7 @@
     </h2>
 
     <div id="{{ div.css_id }}" class="accordion-collapse collapse{% if div.active %} show{% endif %}"
-         aria-labelledby="{{ div.css_id }}" data-bs-parent="#accordion">
+         aria-labelledby="{{ div.css_id }}" {% if not div.always_open %} data-bs-parent="#{{ div.data_parent }}" {% endif %}>
         <div class="accordion-body">
             {{ fields|safe }}
         </div>


### PR DESCRIPTION
Currently, we get a JS error (Uncaught TypeError: 'querySelectorAll' called on an object that does not implement interface Element.)

This, as is, fixes the expected default behavior (see https://getbootstrap.com/docs/5.0/components/accordion/#example).
If implemented the right kwarg in Container class on bootstrap.py, this will also allow for the always open behavior (see https://getbootstrap.com/docs/5.0/components/accordion/#always-open), since all we need is get rid of data-bs-parent.