### PR TITLE
Add support for accordion-flush and accordion always open

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ This template pack include a layout object to use this input type::
         FloatingField("first_name"),
     )
 
+Accordions also have new features, such as [Accordion flush](https://getbootstrap.com/docs/5.0/components/accordion/#flush) and [Always open](https://getbootstrap.com/docs/5.0/components/accordion/#always-open).
+There is a new layout object to use them::
+
+    from crispy_bootstrap5.bootstrap5 import BS5Accordion
+
+    # then in your Layout
+    # if not informed, flush and always_open default to False
+    ... Layout(
+        BS5Accordion(
+            AccordionGroup("group name", "form_field_1", "form_field_2"),
+            AccordionGroup("another group name", "form_field"),
+            flush=True,
+            always_open=True
+        )
+    )
+
+
 ## Development
 
 To contribute to this library, first checkout the code. Then create a new virtual environment:

--- a/crispy_bootstrap5/bootstrap5.py
+++ b/crispy_bootstrap5/bootstrap5.py
@@ -1,3 +1,4 @@
+from crispy_forms.bootstrap import Accordion
 from crispy_forms.layout import Field
 
 
@@ -7,3 +8,26 @@ class FloatingField(Field):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.attrs["placeholder"] = self.fields[0]
+
+
+class BS5Accordion(Accordion):
+    """
+    Bootstrap5 Accordion menu object. It wraps `AccordionGroup` objects in a
+    container. It also allows the usage of accordion-flush, introduced in bootstrap5::
+
+        BS5Accordion(
+            AccordionGroup("group name", "form_field_1", "form_field_2"),
+            AccordionGroup("another group name", "form_field"),
+            flush=True,
+            always_open=True
+        )
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.flush = kwargs.pop("flush", False)
+        self.always_open = kwargs.pop("always_open", False)
+
+        if self.always_open:
+            for accordion_group in self.fields:
+                accordion_group.always_open = True

--- a/crispy_bootstrap5/templates/bootstrap5/accordion-group.html
+++ b/crispy_bootstrap5/templates/bootstrap5/accordion-group.html
@@ -7,7 +7,7 @@
     </h2>
 
     <div id="{{ div.css_id }}" class="accordion-collapse collapse{% if div.active %} show{% endif %}"
-         aria-labelledby="{{ div.css_id }}" data-bs-parent="#accordion">
+         aria-labelledby="{{ div.css_id }}" {% if not div.always_open %} data-bs-parent="#{{ div.data_parent }}" {% endif %}>
         <div class="accordion-body">
             {{ fields|safe }}
         </div>

--- a/crispy_bootstrap5/templates/bootstrap5/accordion.html
+++ b/crispy_bootstrap5/templates/bootstrap5/accordion.html
@@ -1,3 +1,3 @@
-<div class="accordion" id="accordion">
+<div class="accordion{% if accordion.flush %} accordion-flush{% endif %}" id="{{ accordion.css_id }}">
     {{ content|safe }}
 </div>

--- a/tests/results/accordion_always_open.html
+++ b/tests/results/accordion_always_open.html
@@ -6,7 +6,7 @@
         one
       </button>
     </h2>
-    <div id="one" class="accordion-collapse collapse show" aria-labelledby="one" data-bs-parent="#accordion-7311">
+    <div id="one" class="accordion-collapse collapse show" aria-labelledby="one">
       <div class="accordion-body">
         <div id="div_id_first_name" class="mb-3">
           <label for="id_first_name" class="form-label requiredField">
@@ -25,7 +25,7 @@
         two
       </button>
     </h2>
-    <div id="two" class="accordion-collapse collapse" aria-labelledby="two" data-bs-parent="#accordion-7311">
+    <div id="two" class="accordion-collapse collapse" aria-labelledby="two">
       <div class="accordion-body">
         <div id="div_id_password1" class="mb-3">
           <label for="id_password1" class="form-label requiredField">

--- a/tests/results/accordion_flush.html
+++ b/tests/results/accordion_flush.html
@@ -1,4 +1,4 @@
-<div class="accordion" id="accordion-7311">
+<div class="accordion accordion-flush" id="accordion-7311">
   <div class="accordion-item">
     <h2 class="accordion-header">
       <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#one"

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 from crispy_forms.bootstrap import (
     Accordion,
@@ -22,7 +24,7 @@ from django.template import Context, Template
 from django.utils.translation import activate, deactivate
 from django.utils.translation import gettext as _
 
-from crispy_bootstrap5.bootstrap5 import FloatingField
+from crispy_bootstrap5.bootstrap5 import BS5Accordion, FloatingField
 
 from .forms import (
     CheckboxesSampleForm,
@@ -221,7 +223,8 @@ class TestBootstrapLayoutObjects:
         html = render_crispy_form(test_form)
         assert html.count('form-check-inline"') == 2
 
-    def test_accordion_and_accordiongroup(self, settings):
+    def test_accordion_and_accordiongroup(self):
+        random.seed(0)
         form = SampleForm()
         form.helper = FormHelper()
         form.helper.form_tag = False
@@ -233,7 +236,7 @@ class TestBootstrapLayoutObjects:
         )
         assert parse_form(form) == parse_expected("accordion.html")
 
-    def test_accordion_active_false_not_rendered(self, settings):
+    def test_accordion_active_false_not_rendered(self):
         test_form = SampleForm()
         test_form.helper = FormHelper()
         test_form.helper.layout = Layout(
@@ -265,6 +268,80 @@ class TestBootstrapLayoutObjects:
             html.count('<div id="one" class="accordion-collapse %s"' % accordion_class)
             == 0
         )
+
+    def test_bs5accordion(self):
+        random.seed(0)
+        form = SampleForm()
+        form.helper = FormHelper()
+        form.helper.form_tag = False
+        form.helper.layout = Layout(
+            BS5Accordion(
+                AccordionGroup("one", "first_name"),
+                AccordionGroup("two", "password1", "password2"),
+            )
+        )
+        assert parse_form(form) == parse_expected("accordion.html")
+
+    def test_bs5accordion_active_false_not_rendered(self):
+        test_form = SampleForm()
+        test_form.helper = FormHelper()
+        test_form.helper.layout = Layout(
+            BS5Accordion(
+                AccordionGroup("one", "first_name"),
+                # there is no ``active`` kwarg here.
+            )
+        )
+
+        # The first time, there should be one of them there.
+        html = render_crispy_form(test_form)
+
+        accordion_class = "collapse show"
+
+        assert (
+            html.count('<div id="one" class="accordion-collapse %s"' % accordion_class)
+            == 1
+        )
+
+        test_form.helper.layout = Layout(
+            BS5Accordion(
+                AccordionGroup("one", "first_name", active=False),
+            )  # now ``active`` manually set as False
+        )
+
+        # This time, it shouldn't be there at all.
+        html = render_crispy_form(test_form)
+        assert (
+            html.count('<div id="one" class="accordion-collapse %s"' % accordion_class)
+            == 0
+        )
+
+    def test_bs5accordion_flush(self):
+        random.seed(0)
+        test_form = SampleForm()
+        test_form.helper = FormHelper()
+        test_form.helper.form_tag = False
+        test_form.helper.layout = Layout(
+            BS5Accordion(
+                AccordionGroup("one", "first_name"),
+                AccordionGroup("two", "password1", "password2"),
+                flush=True,
+            )
+        )
+        assert parse_form(test_form) == parse_expected("accordion_flush.html")
+
+    def test_bs5accordion_always_open(self):
+        random.seed(0)
+        test_form = SampleForm()
+        test_form.helper = FormHelper()
+        test_form.helper.form_tag = False
+        test_form.helper.layout = Layout(
+            BS5Accordion(
+                AccordionGroup("one", "first_name"),
+                AccordionGroup("two", "password1", "password2"),
+                always_open=True,
+            )
+        )
+        assert parse_form(test_form) == parse_expected("accordion_always_open.html")
 
     def test_alert(self):
         test_form = SampleForm()


### PR DESCRIPTION
This addresses #60, #61 and #62. Tests should work now.

The term "always open" sounds misleading to me, but it's what the folks at Bootstrap use. We could change this to something more descriptive if judged necessary.

I'm not sure about the way I pulled classes from bootstrap.py. It feels awkward. I was inheriting from the original classes before and adding just what I needed, but it somehow felt worse. Any suggestions?
