### PR TITLE
Removed |safe filter from help text

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/help_text.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/help_text.html
@@ -1,7 +1,7 @@
 {% if field.help_text %}
     {% if help_text_inline %}
-        <span id="hint_{{ field.auto_id }}" class="text-muted">{{ field.help_text|safe }}</span>
+        <span id="hint_{{ field.auto_id }}" class="text-muted">{{ field.help_text }}</span>
     {% else %}
-        <small id="hint_{{ field.auto_id }}" class="form-text text-muted">{{ field.help_text|safe }}</small>
+        <small id="hint_{{ field.auto_id }}" class="form-text text-muted">{{ field.help_text }}</small>
     {% endif %}
 {% endif %}

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -284,3 +284,12 @@ class GroupedChoiceForm(forms.Form):
         widget=forms.CheckboxSelectMultiple, choices=choices
     )
     radio = forms.MultipleChoiceField(widget=forms.RadioSelect, choices=choices)
+
+
+class HelpTextForm(forms.Form):
+    email = forms.EmailField(
+        label="email",
+        required=True,
+        widget=forms.TextInput(),
+        help_text="Insert your email<>&",
+    )

--- a/tests/results/help_text_escape.html
+++ b/tests/results/help_text_escape.html
@@ -1,0 +1,5 @@
+<div class="mb-3" id="div_id_email"><label class="form-label requiredField" for="id_email">email<span
+            class="asteriskField">*</span></label><input class="form-control inputtext textInput textinput"
+        id="id_email" name="email" required type="text"><small class="form-text text-muted" id="hint_id_email">Insert
+        your email&lt;&gt;&amp;</small>
+</div>

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -25,6 +25,7 @@ from .forms import (
     CrispyTestModel,
     FileForm,
     FileFormRequired,
+    HelpTextForm,
     InputsForm,
     LabelForm,
     SampleForm,
@@ -640,3 +641,10 @@ def test_flat_attrs_safe():
     )
     form.helper.form_tag = False
     assert parse_form(form) == parse_expected("flat_attrs.html")
+
+
+def test_help_text_escape():
+    form = HelpTextForm()
+    form.helper = FormHelper()
+    form.helper.form_tag = False
+    assert parse_form(form) == parse_expected("help_text_escape.html")


### PR DESCRIPTION
Another couple of the `|safe` filters removed, this time from the help text.

![image](https://user-images.githubusercontent.com/39445562/122290560-c99bcf00-ceeb-11eb-9a16-8c8d434a1f89.png)
