### PR TITLE
Fix floating field select

### DIFF
--- a/crispy_bootstrap5/bootstrap5.py
+++ b/crispy_bootstrap5/bootstrap5.py
@@ -5,9 +5,6 @@ from crispy_forms.layout import Field
 class FloatingField(Field):
     template = "bootstrap5/layout/floating_field.html"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
 
 class BS5Accordion(Accordion):
     """

--- a/crispy_bootstrap5/bootstrap5.py
+++ b/crispy_bootstrap5/bootstrap5.py
@@ -7,7 +7,6 @@ class FloatingField(Field):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.attrs["placeholder"] = self.fields[0]
 
 
 class BS5Accordion(Accordion):

--- a/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
@@ -5,11 +5,19 @@
 {% else %}
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="form-floating mb-3{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
     
-    {% if field.errors %}
-        {% crispy_field field 'class' 'form-control is-invalid'%}
+    {% if field|is_select %}
+        {%if field.errors %}
+            {% crispy_field field 'class' 'form-select is-invalid' %}
+        {% else %}
+            {% crispy_field field 'class' 'form-select' %}
+        {% endif %}
     {% else %}
-        {% crispy_field field 'class' 'form-control' %}
-    {% endif %}    
+        {% if field.errors %}
+            {% crispy_field field 'class' 'form-control is-invalid' %}
+        {% else %}
+            {% crispy_field field 'class' 'form-control' %}
+        {% endif %} 
+    {% endif %} 
     
     <label {% if field.id_for_label %}for="{{ field.id_for_label }}"{% endif %}{% if label_class %} class="{{ label_class }}"{% endif %}>
         {{ field.label }}

--- a/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
@@ -7,15 +7,15 @@
     
     {% if field|is_select %}
         {%if field.errors %}
-            {% crispy_field field 'class' 'form-select is-invalid' %}
+            {% crispy_field field 'class' 'form-select is-invalid' 'placeholder' field.name %}
         {% else %}
-            {% crispy_field field 'class' 'form-select' %}
+            {% crispy_field field 'class' 'form-select' 'placeholder' field.name %}
         {% endif %}
     {% else %}
         {% if field.errors %}
-            {% crispy_field field 'class' 'form-control is-invalid' %}
+            {% crispy_field field 'class' 'form-control is-invalid' 'placeholder' field.name %}
         {% else %}
-            {% crispy_field field 'class' 'form-control' %}
+            {% crispy_field field 'class' 'form-control' 'placeholder' field.name %}
         {% endif %} 
     {% endif %} 
     

--- a/tests/results/test_floating_field_failing.html
+++ b/tests/results/test_floating_field_failing.html
@@ -3,7 +3,7 @@
             id="id_text_area" name="text_area" placeholder="text_area" required rows="10"></textarea><label
             for="id_text_area">Text area</label><span class="invalid-feedback" id="error_1_id_text_area"><strong>This
                 field is required.</strong></span></div>
-    <div class="form-floating mb-3" id="div_id_select_input"><select class="form-control is-invalid select"
+    <div class="form-floating mb-3" id="div_id_select_input"><select class="form-select is-invalid select"
             id="id_select_input" name="select_input" placeholder="select_input">
             <option value="1">Option one</option>
             <option value="2">Option two</option>

--- a/tests/results/test_floating_field_failing.html
+++ b/tests/results/test_floating_field_failing.html
@@ -1,13 +1,25 @@
-<form method="post">
-    <div class="form-floating mb-3" id="div_id_text_area"><textarea class="form-control is-invalid textarea" cols="40"
-            id="id_text_area" name="text_area" placeholder="text_area" required rows="10"></textarea><label
-            for="id_text_area">Text area</label><span class="invalid-feedback" id="error_1_id_text_area"><strong>This
-                field is required.</strong></span></div>
-    <div class="form-floating mb-3" id="div_id_select_input"><select class="form-select is-invalid select"
-            id="id_select_input" name="select_input" placeholder="select_input">
+<form  method="post" >
+    <div id="div_id_text_area" class="form-floating mb-3">
+        <textarea name="text_area" cols="40" rows="10" placeholder="text_area" class="textarea form-control is-invalid" required id="id_text_area">
+        </textarea>
+        <label for="id_text_area">
+            Text area
+        </label>
+        <span id="error_1_id_text_area" class="invalid-feedback">
+            <strong>This field is required.</strong>
+        </span>
+    </div>
+    <div id="div_id_select_input" class="form-floating mb-3">
+        <select name="select_input" placeholder="select_input" class="select form-select is-invalid" id="id_select_input">
             <option value="1">Option one</option>
             <option value="2">Option two</option>
             <option value="3">Option three</option>
-        </select><label for="id_select_input">Select input</label><span class="invalid-feedback"
-            id="error_1_id_select_input"><strong>This field is required.</strong></span></div>
+        </select>
+        <label for="id_select_input">
+            Select input
+        </label>
+        <span id="error_1_id_select_input" class="invalid-feedback">
+            <strong>This field is required.</strong>
+        </span>
+    </div>
 </form>


### PR DESCRIPTION
Select fields need to have a form-select class instead of a form-control class [see here](https://getbootstrap.com/docs/5.0/forms/select/). This is already handled correctly for normal select fields, this adds support for floating select fields which are also supported by bootstrap [see here](https://getbootstrap.com/docs/5.0/forms/floating-labels/#selects). I have modified the test to work with the new floating select field.