### PR TITLE
Build package with build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,11 +50,11 @@ jobs:
             ${{ runner.os }}-publish-pip-
       - name: Install dependencies
         run: |
-          pip install setuptools wheel twine
+          pip install build twine
       - name: Publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*


### PR DESCRIPTION
Building packages with setup.py is deprecated, the currently recommended command is `python -m build`. See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Note, build creates an isolated environment and therefore installs wheel/setuptools into it. I think let's try it with this package, and then can look at others once it's working here. 