### PR TITLE
Add missing class to checkbox wrapper

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/field.html
@@ -9,7 +9,7 @@
             <div class="{% for offset in bootstrap_checkbox_offsets %}{{ offset|slice:"7:14" }}{{ offset|slice:"4:7" }}{{ offset|slice:"14:16" }} {% endfor %}{{ field_class }}">
         {% endif %}
     {% endif %}
-    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="mb-3{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="mb-3{% if field|is_checkbox and form_show_labels %} form-check{% else %}{% if 'form-horizontal' in form_class %} row{% endif %}{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
            {# not field|is_radioselect in row below can be removed once Django 3.2 is no longer supported #}
             <label {% if field.id_for_label and not field|is_radioselect %}for="{{ field.id_for_label }}"{% endif %} class="{% if 'form-horizontal' in form_class %}col-form-label{% else %}form-label{% endif %}{% if label_class %} {{ label_class }}{% endif %}{% if field.field.required %} requiredField{% endif %}">

--- a/tests/results/single_checkbox.html
+++ b/tests/results/single_checkbox.html
@@ -1,6 +1,6 @@
 <form method="post">
   <div class="mb-3">
-    <div id="div_id_single_checkbox" class="mb-3">
+    <div id="div_id_single_checkbox" class="mb-3 form-check">
       <input
         type="checkbox"
         name="single_checkbox"


### PR DESCRIPTION
From the [docs](https://getbootstrap.com/docs/5.1/forms/checks-radios/#checks), checkboxes should have the `form-check` class on their wrapper element, unless the [label is omitted](https://getbootstrap.com/docs/5.1/forms/checks-radios/#without-labels):

```html
<div class="form-check">
  <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">
  <label class="form-check-label" for="flexCheckDefault">
    Default checkbox
  </label>
</div>

<div>
  <input class="form-check-input" type="checkbox" id="checkboxNoLabel" value="" aria-label="...">
</div>
```

This PR adds this logic.
