### PR TITLE
fix prepended/appended_text not rendering html content

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/prepended_appended_text.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/prepended_appended_text.html
@@ -15,7 +15,7 @@
             <div class="input-group{% if input_size %} {{ input_size }}{% endif %}">
                 {# prepend #}
                 {% if crispy_prepended_text %}
-                    <span class="input-group-text">{{ crispy_prepended_text }}</span>
+                    <span class="input-group-text">{{ crispy_prepended_text|safe }}</span>
                 {% endif %}
 
                 {# input #}
@@ -33,7 +33,7 @@
                 
                 {# append #}
                 {% if crispy_appended_text %}
-                    <span class="input-group-text">{{ crispy_appended_text }}</span>
+                    <span class="input-group-text">{{ crispy_appended_text|safe }}</span>
                 {% endif %}
                 {% if error_text_inline %}
                     {% include 'bootstrap5/layout/field_errors.html' %}


### PR DESCRIPTION
This should be in the code, as the [Crispy forms docs](https://django-crispy-forms.readthedocs.io/en/latest/layouts.html?highlight=tabs#bootstrap-layout-objects) say that this is possible, and in the corresponding bootstrap3 component it is included.
fixes #94