### PR TITLE
Fix label text for required Floating Fields

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
@@ -20,7 +20,7 @@
     {% endif %} 
     
     <label {% if field.id_for_label %}for="{{ field.id_for_label }}"{% endif %}{% if label_class %} class="{{ label_class }}"{% endif %}>
-        {{ field.label }}
+        {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
     </label>
 
     {% include 'bootstrap5/layout/help_text_and_errors.html' %}

--- a/tests/results/test_floating_field.html
+++ b/tests/results/test_floating_field.html
@@ -1,5 +1,5 @@
 <form method="post">
     <div class="form-floating mb-3" id="div_id_first_name"><input class="form-control inputtext textInput textinput"
             id="id_first_name" maxlength="5" name="first_name" placeholder="first_name" required type="text"><label
-            for="id_first_name">first name</label></div>
+            for="id_first_name">first name<span class="asteriskField">*</span></label></div>
 </form>

--- a/tests/results/test_floating_field_failing.html
+++ b/tests/results/test_floating_field_failing.html
@@ -3,7 +3,7 @@
         <textarea name="text_area" cols="40" rows="10" placeholder="text_area" class="textarea form-control is-invalid" required id="id_text_area">
         </textarea>
         <label for="id_text_area">
-            Text area
+            Text area<span class="asteriskField">*</span>
         </label>
         <span id="error_1_id_text_area" class="invalid-feedback">
             <strong>This field is required.</strong>
@@ -16,7 +16,7 @@
             <option value="3">Option three</option>
         </select>
         <label for="id_select_input">
-            Select input
+            Select input<span class="asteriskField">*</span>
         </label>
         <span id="error_1_id_select_input" class="invalid-feedback">
             <strong>This field is required.</strong>


### PR DESCRIPTION
- For Floating Fields, added an asterisk (*) to the end of label text
  to denote a required field.
- Enclosed the * in a span tag with the required styling (see link
  below for more info about styling the required fields asterisk)
- Updated test result files to reflect these changes.

Asterisk CSS stying info:
https://django-crispy-forms.readthedocs.io/en/latest/crispy_tag_forms.html?highlight=asteriskField#change-required-field