### PR TITLE
removed inline style for CSP compliancy

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/field_file.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/field_file.html
@@ -6,7 +6,7 @@
 <div class="input-group mb-2">
     <span class="input-group-text">{{ widget.data.initial_text }}</span>
     <div class="form-control d-flex h-auto">
-        <span class="text-break" style="flex-grow:1;min-width:0">
+        <span class="text-break flex-grow-1">
             <a href="{{ field.value.url }}">{{ field.value.name }}</a>
         </span>
         {% if not widget.data.required %}


### PR DESCRIPTION
This change works in my local project, and removes the CSP issues related to crispy_forms. 
However, you might want to check whether the omission of the min-width has any effect, or whether this can be acheived through the different flex-{*}-grow-* classes. Unfortunately, I am not an expert on bootstrap5 classes.