### PR TITLE
Move radio checkbox select help text out of div

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/radio_checkbox_select.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/radio_checkbox_select.html
@@ -17,11 +17,11 @@
      </div>
     {% endfor %}
     {% endfor %}
-    {% if field.errors and inline_class %}
-        {% for error in field.errors %}
-            <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="text-danger mb-0"><small><strong>{{ error }}</strong></small></p>
-        {% endfor %}
-    {% endif %}
 
-    {% include 'bootstrap5/layout/help_text.html' %}
 </div>
+{% if field.errors and inline_class %}
+    {% for error in field.errors %}
+        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="text-danger mb-0"><small><strong>{{ error }}</strong></small></p>
+    {% endfor %}
+{% endif %}
+{% include 'bootstrap5/layout/help_text.html' %}

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -281,7 +281,9 @@ class GroupedChoiceForm(forms.Form):
         ("unknown", "Unknown"),
     ]
     checkbox_select_multiple = forms.MultipleChoiceField(
-        widget=forms.CheckboxSelectMultiple, choices=choices
+        widget=forms.CheckboxSelectMultiple,
+        choices=choices,
+        help_text="help",
     )
     radio = forms.MultipleChoiceField(widget=forms.RadioSelect, choices=choices)
 

--- a/tests/results/test_grouped_checkboxes.html
+++ b/tests/results/test_grouped_checkboxes.html
@@ -18,5 +18,8 @@
                     name="checkbox_select_multiple" type="checkbox" value="unknown"><label class="form-check-label"
                     for="id_checkbox_select_multiple_2">Unknown</label></div>
         </div>
+        <div class="form-text" id="hint_id_checkbox_select_multiple">
+            help
+        </div>
     </div>
 </form>

--- a/tests/results/test_grouped_checkboxes_failing.html
+++ b/tests/results/test_grouped_checkboxes_failing.html
@@ -21,5 +21,8 @@
                         required.</strong></p>
             </div>
         </div>
+        <div class="form-text" id="hint_id_checkbox_select_multiple">
+            help
+        </div>
     </div>
 </form>


### PR DESCRIPTION
Currently, the help text is included in the div, if a scroll class is added to `field_class`, it will result in the errors and help text being shown as part of the scroll and have to scroll to the bottom of the inner container to see it. This likely won't be surprising as the other fields, the help text are beside the input and not within the input container.

In our case, we have overridden the `field_class` with `Field('industry', css_class="industry-scroll"),` and added the css

```css
.industry-scroll {
  overflow-y: scroll !important;
  max-height: 300px !important;
}
```

Before: help text is scrolling with content (showing at the end of the inner container)

<img width="841" alt="image(1)" src="https://user-images.githubusercontent.com/4687791/192424622-573202c2-0f9c-42bf-8772-0a06a33ca51a.png">

Before: help text is scrolling with content (helptext is not visible at first)

<img width="830" alt="image(2)" src="https://user-images.githubusercontent.com/4687791/192424649-cf7a913a-ed32-425d-8031-51e22721b505.png">

After

<img width="833" alt="image" src="https://user-images.githubusercontent.com/4687791/192424599-b2700fe1-bbf3-425a-b9db-11a47297500b.png">
