### PR TITLE
Fixed tests for crispy-forms 2x

### DIFF
--- a/tests/templates/custom_field_template.html
+++ b/tests/templates/custom_field_template.html
@@ -1,2 +1,2 @@
 <h1>Special custom field</h1>
-{% include 'bootstrap/field.html' %}
+{% include 'bootstrap5/field.html' %}

--- a/tests/templates/custom_form_template.html
+++ b/tests/templates/custom_form_template.html
@@ -1,2 +1,2 @@
 <h1>Special custom form</h1>
-{% include "bootstrap/whole_uni_form.html" %}
+{% include "bootstrap5/whole_uni_form.html" %}

--- a/tests/templates/custom_form_template_with_context.html
+++ b/tests/templates/custom_form_template_with_context.html
@@ -1,4 +1,4 @@
 <h1>Special custom form with context passthrough</h1>
 Got prefix: {{ prefix }}.
-{% include "bootstrap/whole_uni_form.html" %}
+{% include "bootstrap5/whole_uni_form.html" %}
 Got suffix: {{ suffix }}.

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -16,6 +16,7 @@ from django.forms.models import formset_factory, modelformset_factory
 from django.middleware.csrf import _get_new_csrf_string
 from django.shortcuts import render
 from django.template import Context, Template
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -35,6 +36,12 @@ from .forms import (
     SampleForm6,
 )
 from .utils import contains_partial, parse_expected, parse_form
+
+CONVERTERS = {
+    "textinput": "inputtext textinput textInput",
+    "fileinput": "fileinput fileUpload",
+    "passwordinput": "textinput textInput",
+}
 
 
 def test_invalid_unicode_characters(settings):
@@ -331,6 +338,7 @@ def test_bs5_field_with_buttons_css_classes():
     assert parse_form(form) == parse_expected("field_with_buttons_failing.html")
 
 
+@override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
 def test_formset_layout():
     SampleFormSet = formset_factory(SampleForm, extra=3)
     formset = SampleFormSet()
@@ -523,6 +531,7 @@ def test_keepcontext_context_manager():
     assert response.content.count(b"form-check-input") > 0
 
 
+@override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
 def test_bootstrap5_form_inline():
     form = SampleForm()
     form.helper = FormHelper()
@@ -557,7 +566,7 @@ def test_update_attributes_class():
     form.helper.layout = Layout("email", Field("password1"), "password2")
     form.helper["password1"].update_attributes(css_class="hello")
     html = render_crispy_form(form)
-    assert html.count(' class="hello textinput') == 1
+    assert html.count(' class="hello') == 1
     form.helper = FormHelper()
     form.helper.layout = Layout(
         "email",
@@ -566,7 +575,7 @@ def test_update_attributes_class():
     )
     form.helper["password1"].update_attributes(css_class="hello2")
     html = render_crispy_form(form)
-    assert html.count(' class="hello hello2 textinput') == 1
+    assert html.count(' class="hello hello2') == 1
 
 
 def test_file_field():
@@ -611,6 +620,7 @@ def test_html_label_escape():
     assert "&lt;&gt;&amp;" in html
 
 
+@override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
 def test_tabular_formset_layout():
     SampleFormSet = formset_factory(SampleForm, extra=3)
     formset = SampleFormSet()

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -21,6 +21,7 @@ from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField
 from crispy_forms.utils import render_crispy_form
 from django import forms
 from django.template import Context, Template
+from django.test import override_settings
 from django.utils.translation import activate, deactivate
 from django.utils.translation import gettext as _
 
@@ -36,6 +37,12 @@ from .forms import (
     SampleFormCustomWidgets,
 )
 from .utils import parse_expected, parse_form
+
+CONVERTERS = {
+    "textinput": "inputtext textinput textInput",
+    "fileinput": "fileinput fileUpload",
+    "passwordinput": "textinput textInput",
+}
 
 
 def test_field_with_custom_template():
@@ -202,6 +209,7 @@ class TestBootstrapLayoutObjects:
         html = render_crispy_form(form)
         assert 'class="form-check-input"' in html
 
+    @override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
     def test_prepended_appended_text(self):
         test_form = SampleForm()
         test_form.helper = FormHelper()
@@ -223,6 +231,7 @@ class TestBootstrapLayoutObjects:
         html = render_crispy_form(test_form)
         assert html.count('form-check-inline"') == 2
 
+    @override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
     def test_accordion_and_accordiongroup(self):
         random.seed(0)
         form = SampleForm()
@@ -269,6 +278,7 @@ class TestBootstrapLayoutObjects:
             == 0
         )
 
+    @override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
     def test_bs5accordion(self):
         random.seed(0)
         form = SampleForm()
@@ -315,6 +325,7 @@ class TestBootstrapLayoutObjects:
             == 0
         )
 
+    @override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
     def test_bs5accordion_flush(self):
         random.seed(0)
         test_form = SampleForm()
@@ -329,6 +340,7 @@ class TestBootstrapLayoutObjects:
         )
         assert parse_form(test_form) == parse_expected("accordion_flush.html")
 
+    @override_settings(CRISPY_CLASS_CONVERTERS=CONVERTERS)
     def test_bs5accordion_always_open(self):
         random.seed(0)
         test_form = SampleForm()

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,6 @@ deps =
     crispy-latest: https://github.com/django-crispy-forms/django-crispy-forms/archive/main.tar.gz
 extras = test
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs}
-ignore_outcome =
-    crispy-latest: True
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Needs #131 first. 

This allows the tests suite to pass with both crispy-forms 1.x and 2.x.