### PR TITLE
Fix the headers of table_inline_formset.html do not display correctly 

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/table_inline_formset.html
+++ b/crispy_bootstrap5/templates/bootstrap5/table_inline_formset.html
@@ -21,7 +21,7 @@
                 <tr>
                     {% for field in formset.forms.0 %}
                         {% if field.label and not field.is_hidden %}
-                            <th for="{{ field.auto_id }}" class="col-form-label {% if field.field.required %}requiredField{% endif %}">
+                            <th for="{{ field.auto_id }}" class="{% if field.field.required %}requiredField{% endif %}">
                                 {{ field.label }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
                             </th>
                         {% endif %}

--- a/tests/results/test_tabular_formset_layout.html
+++ b/tests/results/test_tabular_formset_layout.html
@@ -6,18 +6,18 @@
 <table class="table table-striped table-sm">
     <thead>
     <tr>
-        <th for="id_form-0-is_company" class="col-form-label "> company </th>
-        <th for="id_form-0-email" class="col-form-label requiredField"> email<span class="asteriskField">*</span>
+        <th for="id_form-0-is_company" class=""> company </th>
+        <th for="id_form-0-email" class="requiredField"> email<span class="asteriskField">*</span>
         </th>
-        <th for="id_form-0-password1" class="col-form-label requiredField"> password<span
+        <th for="id_form-0-password1" class="requiredField"> password<span
             class="asteriskField">*</span> </th>
-        <th for="id_form-0-password2" class="col-form-label requiredField"> re-enter password<span
+        <th for="id_form-0-password2" class="requiredField"> re-enter password<span
             class="asteriskField">*</span> </th>
-        <th for="id_form-0-first_name" class="col-form-label requiredField"> first name<span
+        <th for="id_form-0-first_name" class="requiredField"> first name<span
             class="asteriskField">*</span> </th>
-        <th for="id_form-0-last_name" class="col-form-label requiredField"> last name<span
+        <th for="id_form-0-last_name" class="requiredField"> last name<span
             class="asteriskField">*</span> </th>
-        <th for="id_form-0-datetime_field" class="col-form-label requiredField"> date time<span
+        <th for="id_form-0-datetime_field" class="requiredField"> date time<span
             class="asteriskField">*</span> </th>
     </tr>
     </thead>

--- a/tests/results/test_tabular_formset_layout_failing.html
+++ b/tests/results/test_tabular_formset_layout_failing.html
@@ -6,18 +6,18 @@
     <table class="table table-sm table-striped">
         <thead>
             <tr>
-                <th class=" col-form-label" for="id_form-0-is_company">company</th>
-                <th class="col-form-label requiredField" for="id_form-0-email">email<span class="asteriskField">*</span>
+                <th class="" for="id_form-0-is_company">company</th>
+                <th class="requiredField" for="id_form-0-email">email<span class="asteriskField">*</span>
                 </th>
-                <th class="col-form-label requiredField" for="id_form-0-password1">password<span
+                <th class="requiredField" for="id_form-0-password1">password<span
                         class="asteriskField">*</span></th>
-                <th class="col-form-label requiredField" for="id_form-0-password2">re-enter password<span
+                <th class="requiredField" for="id_form-0-password2">re-enter password<span
                         class="asteriskField">*</span></th>
-                <th class="col-form-label requiredField" for="id_form-0-first_name">first name<span
+                <th class="requiredField" for="id_form-0-first_name">first name<span
                         class="asteriskField">*</span></th>
-                <th class="col-form-label requiredField" for="id_form-0-last_name">last name<span
+                <th class="requiredField" for="id_form-0-last_name">last name<span
                         class="asteriskField">*</span></th>
-                <th class="col-form-label requiredField" for="id_form-0-datetime_field">date time<span
+                <th class="requiredField" for="id_form-0-datetime_field">date time<span
                         class="asteriskField">*</span></th>
             </tr>
         </thead>


### PR DESCRIPTION
The headers of the table do not display correctly using the table_inline_formset.html template to render a inline formset

**Before**

![imagen](https://user-images.githubusercontent.com/8385910/225029684-ef6d9e4a-e68d-47fe-ad5c-7a4b9f3142e6.png)

**After**

![imagen](https://user-images.githubusercontent.com/8385910/225029910-5c9148c0-d51d-4c77-8e8f-edf1a8c87376.png)

fix #139 