### PR TITLE
Add Python 3.12 to test matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.12 is formally supported but not present in the test matrix.