### PR TITLE
remove form_style from fieldset template

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/fieldset.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/fieldset.html
@@ -1,5 +1,5 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
-    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
+    {% if fieldset.css_class %}class="{{ fieldset.css_class }}"{% endif %}
     {{ fieldset.flat_attrs }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
     {{ fields|safe }} 


### PR DESCRIPTION
From what I see, `form_style` was removed from the main code and it does not appear in the corresponding template of `crispy-bootstrap4`.
I do not see any references in the current documentation either.
The name reference from template blasts debugging error output on my system.
Please consider removing the `form_style`.

PS
Mind the `crispy-bootstrap4` does not use "safe" filters while the `crispy-bootstrap5` does.