### PR TITLE
Fix FormHelper field_label attribute for FloatingField (#198)

### DIFF
--- a/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
+++ b/crispy_bootstrap5/templates/bootstrap5/layout/floating_field.html
@@ -3,17 +3,17 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="form-floating mb-3{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="form-floating mb-3{% if field_class %} {{ field_class }}{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
     
     {% if field|is_select %}
-        {%if field.errors %}
+        {% if field.errors %}
             {% crispy_field field 'class' 'form-select is-invalid' 'placeholder' field.name %}
         {% else %}
             {% crispy_field field 'class' 'form-select' 'placeholder' field.name %}
         {% endif %}
     {% else %}
         {% if field.errors %}
-            {% crispy_field field 'class' 'form-control is-invalid' 'placeholder' field.name %}
+            {% crispy_field field 'class' 'form-control is-invalid' 'placeholder' field.name %} 
         {% else %}
             {% crispy_field field 'class' 'form-control' 'placeholder' field.name %}
         {% endif %} 

--- a/tests/results/test_floating_field_field_label.html
+++ b/tests/results/test_floating_field_field_label.html
@@ -1,0 +1,5 @@
+<form method="post">
+    <div class="form-floating mb-3 col-lg-8" id="div_id_first_name"><input class="form-control inputtext textInput textinput"
+            id="id_first_name" maxlength="5" name="first_name" placeholder="first_name" required type="text"><label
+            for="id_first_name">first name<span class="asteriskField">*</span></label></div>
+</form>

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -586,6 +586,14 @@ class TestBootstrapLayoutObjects:
         )
         assert parse_form(form) == parse_expected("test_floating_field.html")
 
+        form = SampleForm()
+        form.helper = FormHelper()
+        form.helper.field_class = 'col-lg-8'
+        form.helper.layout = Layout(
+            FloatingField('first_name'),
+        )
+        assert parse_form(form) == parse_expected('test_floating_field_field_label.html')
+
         form = InputsForm({})
         form.helper = FormHelper()
         form.helper.layout = Layout(


### PR DESCRIPTION
A simple fix and test to add the field_label to the FloatingField layout object.