### PR TITLE
Used PEP 735 Dependency Groups.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,15 @@ dependencies = [
   "django>=4.2",
   "django-crispy-forms>=2.3",
 ]
-[project.optional-dependencies]
+[dependency-groups]
 test = [
   "pytest",
   "pytest-django",
+]
+lint = [
+  "black",
+  "isort",
+  "flake8",
 ]
 [project.urls]
 "CI" = "https://github.com/django-crispy-forms/crispy-bootstrap5/actions"

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     django52: django>=5.2a1,<5.3
     crispy-release: django-crispy-forms>=2.3
     crispy-latest: https://github.com/django-crispy-forms/django-crispy-forms/archive/main.tar.gz
-extras = test
+dependency_groups = test
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs}
 
 [testenv:lint]
@@ -24,10 +24,7 @@ commands =
     black crispy_bootstrap5 --check
     isort crispy_bootstrap5 --check --dif
     flake8 crispy_bootstrap5
-deps =
-    black
-    flake8
-    isort
+dependency_groups = lint
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Dependency groups means that development extras are no longer are shown in project metadata. 

https://pypi.org/project/crispy-bootstrap5/

![image](https://github.com/user-attachments/assets/07345cc0-2277-483d-9ba4-00cd9cfe1d2d)

This patch should reuslt in the current `provides-extra` no longer appearing on PyPI.  I've also taken the opportunity to change the lint dependencies to also use a dependency group. 

Given this is a recent feature, let's see what old versions of Python/pip have to say about it 🤞 