### PR TITLE
PEP 639 licenses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,12 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [
-  "setuptools>=61",
-]
+requires = ["setuptools>=77.0.3"]
 
 [project]
 name="crispy-bootstrap5"
 description="Bootstrap5 template pack for django-crispy-forms"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 authors = [{name = "David Smith"}]
 requires-python = ">=3.9"
 classifiers=[
@@ -19,7 +17,6 @@ classifiers=[
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
https://peps.python.org/pep-0639/ specifies how licenses are to be documented.

The guide here https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/ is helpful.

1. Switch the 'MIT License' classifier to use 'license = "MIT"' instead. (As in the 'basic example' in the PyPA guide.

2. Bump setuptools version to minimum version with PEP 639 support.