### PR TITLE
Confirmed support for Django 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG FOR CRISPY-BOOTSTRAP5
 
+## Next release
+* Confirmed support for Django 6.1.
+
 ## 2026.3 (2026-03-01)
 * Confirmed support for Django 6.0.
 * Dropped support for Django 4.2, 5.0 and 5.1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="Bootstrap5 template pack for django-crispy-forms"
 readme = "README.md"
 license = "MIT"
 authors = [{name = "David Smith"}]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers=[
   "Environment :: Web Environment",
   "Framework :: Django",
@@ -29,7 +29,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "django>=4.2",
+  "django>=5.2",
   "django-crispy-forms>=2.3",
 ]
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers=[
   "Framework :: Django",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -49,7 +50,7 @@ lint = [
 "Issues" = "https://github.com/django-crispy-forms/crispy-bootstrap5/issues"
 
 [tool.setuptools.dynamic]
-version = {attr = "crispy_bootstrap5.__version__"}
+version = { attr = "crispy_bootstrap5.__version__" }
 
 [tool.isort]
 profile = "black"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py310,py311}-django{52}-crispy{-release,-latest},
-    {py312,py313,py314}-django{52,60,-latest}-crispy{-release,-latest},
+    {py312,py313,py314}-django{52,60,61,-latest}-crispy{-release,-latest},
     lint
 
 [testenv]
@@ -10,6 +10,7 @@ wheel_build_env = .pkg
 deps =
     django52: django>=5.2a1,<5.3
     django60: django>=6.0a1,<6.1
+    django61: django>=6.1a1,<6.2
     crispy-release: django-crispy-forms>=2.3
     crispy-latest: https://github.com/django-crispy-forms/django-crispy-forms/archive/main.tar.gz
 dependency_groups = test


### PR DESCRIPTION
Confirmed support for Django 6.1. 

Also updated minimum versions  in pyproject.toml as a preliminary commit as this was missed in e03c9b1d11362a98adbfaddfbd250f6f69f00634